### PR TITLE
feat: implement WaitForPopup functionality and corresponding tests, add documentation for popups

### DIFF
--- a/page.go
+++ b/page.go
@@ -36,7 +36,27 @@ func newPage(c *BrowserContext) (*Page, error) {
 		return nil, err
 	}
 
-	attachRes, err := proto.TargetAttachToTarget(createRes.TargetID).
+	p, err := attachToTarget(c, createRes.TargetID)
+	if err != nil {
+		return nil, err
+	}
+
+	if c.cfg.statePath != "" {
+		if err := c.LoadState(c.cfg.statePath); err != nil {
+			return nil, err
+		}
+	}
+
+	return p, nil
+}
+
+func attachToTarget(
+	c *BrowserContext,
+	targetID proto.TargetTargetID,
+) (*Page, error) {
+	browserExecCtx := c.browser.execCtx()
+
+	attachRes, err := proto.TargetAttachToTarget(targetID).
 		WithFlatten(true).
 		Do(browserExecCtx)
 	if err != nil {
@@ -72,7 +92,7 @@ func newPage(c *BrowserContext) (*Page, error) {
 
 	p := &Page{
 		browserCtx:     c,
-		targetID:       createRes.TargetID,
+		targetID:       targetID,
 		sessionID:      sessionID,
 		session:        session,
 		execCtx:        execCtx,
@@ -119,12 +139,6 @@ func newPage(c *BrowserContext) (*Page, error) {
 	}
 
 	c.addPage(p)
-
-	if c.cfg.statePath != "" {
-		if err := c.LoadState(c.cfg.statePath); err != nil {
-			return nil, err
-		}
-	}
 
 	return p, nil
 }

--- a/page_popup.go
+++ b/page_popup.go
@@ -1,0 +1,81 @@
+package bonk
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/joakimcarlsson/bonk/proto"
+)
+
+// PopupOption configures WaitForPopup behavior.
+type PopupOption func(*popupConfig)
+
+type popupConfig struct {
+	timeout time.Duration
+}
+
+// PopupTimeout sets the maximum time to wait for a popup.
+func PopupTimeout(d time.Duration) PopupOption {
+	return func(c *popupConfig) {
+		c.timeout = d
+	}
+}
+
+// WaitForPopup waits for a new page (tab/popup) to be opened by this page
+// and returns it. The caller should trigger the popup after calling this method.
+func (p *Page) WaitForPopup(opts ...PopupOption) (*Page, error) {
+	cfg := &popupConfig{timeout: p.defaultTimeout}
+	for _, o := range opts {
+		o(cfg)
+	}
+
+	browserExecCtx := p.browserCtx.browser.execCtx()
+
+	if err := proto.TargetSetDiscoverTargets(true).Do(browserExecCtx); err != nil {
+		return nil, err
+	}
+
+	result := make(chan *Page, 1)
+	errCh := make(chan error, 1)
+
+	unsub := p.browserCtx.browser.conn.Subscribe(
+		proto.TargetEventTargetCreatedMethod,
+		func(params json.RawMessage) {
+			var ev proto.TargetEventTargetCreated
+			if err := json.Unmarshal(params, &ev); err != nil {
+				return
+			}
+
+			if ev.TargetInfo.OpenerID != p.targetID {
+				return
+			}
+			if ev.TargetInfo.Type != "page" {
+				return
+			}
+
+			popup, err := attachToTarget(p.browserCtx, ev.TargetInfo.TargetID)
+			if err != nil {
+				select {
+				case errCh <- err:
+				default:
+				}
+				return
+			}
+
+			select {
+			case result <- popup:
+			default:
+			}
+		},
+	)
+	defer unsub()
+
+	select {
+	case popup := <-result:
+		return popup, nil
+	case err := <-errCh:
+		return nil, err
+	case <-time.After(cfg.timeout):
+		return nil, &TimeoutError{Operation: "waiting for popup"}
+	}
+}

--- a/tests/integration/popup_test.go
+++ b/tests/integration/popup_test.go
@@ -1,0 +1,100 @@
+package integration
+
+import (
+	"testing"
+	"time"
+
+	"github.com/joakimcarlsson/bonk"
+)
+
+func TestWaitForPopup(t *testing.T) {
+	b := launchBrowser(t)
+	page := newPage(t, b)
+
+	page.Navigate("https://example.com")
+
+	popupCh := make(chan *bonk.Page, 1)
+	errCh := make(chan error, 1)
+	go func() {
+		popup, err := page.WaitForPopup()
+		if err != nil {
+			errCh <- err
+			return
+		}
+		popupCh <- popup
+	}()
+
+	time.Sleep(100 * time.Millisecond)
+	page.Evaluate("window.open('https://example.com', '_blank')")
+
+	select {
+	case popup := <-popupCh:
+		defer popup.Close()
+		title, err := popup.Title()
+		if err != nil {
+			t.Fatalf("popup title: %v", err)
+		}
+		if title == "" {
+			t.Error("popup title is empty")
+		}
+	case err := <-errCh:
+		t.Fatalf("WaitForPopup: %v", err)
+	case <-time.After(10 * time.Second):
+		t.Fatal("timeout waiting for popup")
+	}
+}
+
+func TestWaitForPopupFromClick(t *testing.T) {
+	b := launchBrowser(t)
+	page := newPage(t, b)
+
+	page.SetContent(
+		`<a id="link" href="https://example.com" target="_blank">Open</a>`,
+	)
+
+	popupCh := make(chan *bonk.Page, 1)
+	errCh := make(chan error, 1)
+	go func() {
+		popup, err := page.WaitForPopup()
+		if err != nil {
+			errCh <- err
+			return
+		}
+		popupCh <- popup
+	}()
+
+	time.Sleep(100 * time.Millisecond)
+	page.Click("#link")
+
+	select {
+	case popup := <-popupCh:
+		defer popup.Close()
+		url, err := popup.URL()
+		if err != nil {
+			t.Fatalf("popup URL: %v", err)
+		}
+		if url == "" {
+			t.Error("popup URL is empty")
+		}
+	case err := <-errCh:
+		t.Fatalf("WaitForPopup: %v", err)
+	case <-time.After(10 * time.Second):
+		t.Fatal("timeout waiting for popup")
+	}
+}
+
+func TestWaitForPopupTimeout(t *testing.T) {
+	b := launchBrowser(t)
+	page := newPage(t, b)
+
+	page.Navigate("https://example.com")
+
+	_, err := page.WaitForPopup(bonk.PopupTimeout(500 * time.Millisecond))
+	if err == nil {
+		t.Fatal("expected timeout error")
+	}
+
+	if _, ok := err.(*bonk.TimeoutError); !ok {
+		t.Fatalf("expected TimeoutError, got %T: %v", err, err)
+	}
+}

--- a/www/docs/events/popups.md
+++ b/www/docs/events/popups.md
@@ -1,0 +1,58 @@
+# Popups & New Tabs
+
+Detect and interact with new pages opened by `window.open` or `target="_blank"` links.
+
+## Wait for a Popup
+
+```go
+// start waiting before triggering the popup
+popupCh := make(chan *bonk.Page, 1)
+go func() {
+    popup, err := page.WaitForPopup()
+    if err != nil {
+        log.Fatal(err)
+    }
+    popupCh <- popup
+}()
+
+// trigger the popup
+page.Click("a[target=_blank]")
+
+// use the popup page
+popup := <-popupCh
+defer popup.Close()
+popup.WaitSelector("#content")
+```
+
+## With window.open
+
+```go
+go func() {
+    popup, _ := page.WaitForPopup()
+    popupCh <- popup
+}()
+
+page.Evaluate("window.open('https://accounts.google.com/login', '_blank')")
+popup := <-popupCh
+```
+
+## Options
+
+| Option | Description |
+|--------|-------------|
+| `PopupTimeout(d time.Duration)` | Maximum time to wait (default: 30s) |
+
+## Custom Timeout
+
+```go
+popup, err := page.WaitForPopup(bonk.PopupTimeout(5 * time.Second))
+if err != nil {
+    log.Fatal("no popup appeared within 5s")
+}
+```
+
+## Common Use Cases
+
+- **OAuth flows** — click "Login with Google", wait for the OAuth popup, fill credentials, then return to the main page
+- **Payment pages** — handle payment provider popups
+- **External links** — verify that `target="_blank"` links open correctly

--- a/www/mkdocs.yml
+++ b/www/mkdocs.yml
@@ -64,6 +64,7 @@ nav:
       - Console: events/console.md
       - Dialogs: events/dialogs.md
       - Downloads: events/downloads.md
+      - Popups: events/popups.md
   - Stealth:
       - Overview: stealth/overview.md
   - Advanced:


### PR DESCRIPTION
closes #6 

This pull request introduces support for detecting and interacting with popup windows (new tabs) in the browser automation library. The main addition is the new `WaitForPopup` method, which allows users to wait for popups triggered by actions like `window.open` or clicking links with `target="_blank"`. The implementation includes configuration options for timeouts, comprehensive integration tests, and user documentation.
