### PR TITLE
feat: enhance locator and element functionalities with new state checks and control methods

### DIFF
--- a/element_input.go
+++ b/element_input.go
@@ -80,6 +80,11 @@ func (e *Element) Fill(text string) error {
 	return proto.InputInsertText(text).Do(e.page.execCtx)
 }
 
+// Clear clears the input field contents.
+func (e *Element) Clear() error {
+	return e.Fill("")
+}
+
 // Type types the given text character by character with key events.
 func (e *Element) Type(text string, opts ...TypeOption) error {
 	cfg := defaultTypeConfig()
@@ -290,6 +295,12 @@ func (e *Element) waitVisible() error {
 
 // Focus focuses the element.
 func (e *Element) Focus() error { return e.focus() }
+
+// Blur removes focus from the element.
+func (e *Element) Blur() error {
+	_, err := e.callForValue("function(){this.blur()}")
+	return err
+}
 
 func (e *Element) focus() error {
 	_, err := e.callForValue("function(){this.focus()}")

--- a/element_query.go
+++ b/element_query.go
@@ -42,6 +42,45 @@ func (e *Element) IsVisible() (bool, error) {
 	return b, nil
 }
 
+// IsChecked reports whether the element is checked (for checkboxes and radio buttons).
+func (e *Element) IsChecked() (bool, error) {
+	res, err := e.callForValue("function(){return !!this.checked}")
+	if err != nil {
+		return false, err
+	}
+	b, _ := res.(bool)
+	return b, nil
+}
+
+// IsDisabled reports whether the element is disabled.
+func (e *Element) IsDisabled() (bool, error) {
+	res, err := e.callForValue("function(){return !!this.disabled}")
+	if err != nil {
+		return false, err
+	}
+	b, _ := res.(bool)
+	return b, nil
+}
+
+// IsEditable reports whether the element accepts input.
+// An element is editable if it is an input, textarea, select, or
+// contenteditable element that is neither disabled nor read-only.
+func (e *Element) IsEditable() (bool, error) {
+	res, err := e.callForValue(
+		"function(){" +
+			"var t=this.tagName;" +
+			"var ce=this.isContentEditable;" +
+			"if(t!=='INPUT'&&t!=='TEXTAREA'&&t!=='SELECT'&&!ce)return false;" +
+			"return !this.disabled&&!this.readOnly" +
+			"}",
+	)
+	if err != nil {
+		return false, err
+	}
+	b, _ := res.(bool)
+	return b, nil
+}
+
 // Box holds an element's bounding rectangle (x, y, width, height).
 type Box struct {
 	X      float64

--- a/locator.go
+++ b/locator.go
@@ -143,6 +143,106 @@ func (l *Locator) IsVisible() (bool, error) {
 	return el.IsVisible()
 }
 
+// IsChecked reports whether the element is checked.
+func (l *Locator) IsChecked() (bool, error) {
+	el, err := l.queryDirect()
+	if err != nil {
+		return false, err
+	}
+	if el == nil {
+		return false, nil
+	}
+	return el.IsChecked()
+}
+
+// IsDisabled reports whether the element is disabled.
+func (l *Locator) IsDisabled() (bool, error) {
+	el, err := l.queryDirect()
+	if err != nil {
+		return false, err
+	}
+	if el == nil {
+		return false, nil
+	}
+	return el.IsDisabled()
+}
+
+// IsEditable reports whether the element accepts input.
+func (l *Locator) IsEditable() (bool, error) {
+	el, err := l.queryDirect()
+	if err != nil {
+		return false, err
+	}
+	if el == nil {
+		return false, nil
+	}
+	return el.IsEditable()
+}
+
+// Focus waits for the element and focuses it.
+func (l *Locator) Focus(opts ...WaitOption) error {
+	l.page.runLocatorHandlers()
+	el, err := l.resolve(opts...)
+	if err != nil {
+		return err
+	}
+	return el.Focus()
+}
+
+// Blur waits for the element and removes focus from it.
+func (l *Locator) Blur(opts ...WaitOption) error {
+	l.page.runLocatorHandlers()
+	el, err := l.resolve(opts...)
+	if err != nil {
+		return err
+	}
+	return el.Blur()
+}
+
+// Clear waits for the element and clears its input value.
+func (l *Locator) Clear(opts ...WaitOption) error {
+	l.page.runLocatorHandlers()
+	el, err := l.resolve(opts...)
+	if err != nil {
+		return err
+	}
+	return el.Clear()
+}
+
+// AllInnerTexts returns the innerText of all matching elements.
+func (l *Locator) AllInnerTexts() ([]string, error) {
+	els, err := l.queryAllElements()
+	if err != nil {
+		return nil, err
+	}
+	texts := make([]string, 0, len(els))
+	for _, el := range els {
+		t, err := el.InnerText()
+		if err != nil {
+			return nil, err
+		}
+		texts = append(texts, t)
+	}
+	return texts, nil
+}
+
+// AllTextContents returns the textContent of all matching elements.
+func (l *Locator) AllTextContents() ([]string, error) {
+	els, err := l.queryAllElements()
+	if err != nil {
+		return nil, err
+	}
+	texts := make([]string, 0, len(els))
+	for _, el := range els {
+		t, err := el.Text()
+		if err != nil {
+			return nil, err
+		}
+		texts = append(texts, t)
+	}
+	return texts, nil
+}
+
 // BoundingBox returns the element's bounding box.
 func (l *Locator) BoundingBox() (*Box, error) {
 	el, err := l.resolve()

--- a/mcp/tools_element.go
+++ b/mcp/tools_element.go
@@ -182,6 +182,72 @@ func registerElementTools(
 	)
 
 	s.AddTool(
+		mcp.NewTool("is_checked",
+			mcp.WithDescription(
+				"Check if a checkbox or radio button is checked.",
+			),
+			mcp.WithString("selector",
+				mcp.Required(),
+				mcp.Description(
+					"CSS selector of the element",
+				),
+			),
+			mcp.WithString("page_id",
+				mcp.Description(
+					"ID of the page. "+
+						"Omit to use the default page.",
+				),
+			),
+		),
+		sess.handleIsChecked,
+	)
+
+	s.AddTool(
+		mcp.NewTool("is_disabled",
+			mcp.WithDescription(
+				"Check if an element is disabled.",
+			),
+			mcp.WithString("selector",
+				mcp.Required(),
+				mcp.Description(
+					"CSS selector of the element",
+				),
+			),
+			mcp.WithString("page_id",
+				mcp.Description(
+					"ID of the page. "+
+						"Omit to use the default page.",
+				),
+			),
+		),
+		sess.handleIsDisabled,
+	)
+
+	s.AddTool(
+		mcp.NewTool("is_editable",
+			mcp.WithDescription(
+				"Check if an element is editable "+
+					"(input, textarea, select, or "+
+					"contenteditable that is not "+
+					"disabled or readonly).",
+			),
+			mcp.WithString("selector",
+				mcp.Required(),
+				mcp.Description(
+					"CSS selector of the element",
+				),
+			),
+			mcp.WithString("page_id",
+				mcp.Description(
+					"ID of the page. "+
+						"Omit to use the default page.",
+				),
+			),
+		),
+		sess.handleIsEditable,
+	)
+
+	s.AddTool(
 		mcp.NewTool("query",
 			mcp.WithDescription(
 				"Find an element and return its text, "+
@@ -530,6 +596,117 @@ func (s *Session) handleUncheck(
 
 	return mcp.NewToolResultText(
 		fmt.Sprintf("Unchecked %q", selector),
+	), nil
+}
+
+func (s *Session) handleIsChecked(
+	_ context.Context,
+	req mcp.CallToolRequest,
+) (*mcp.CallToolResult, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	selector, err := req.RequireString("selector")
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+
+	page, _, err := s.pageFromRequest(req)
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+
+	el, err := page.Query(selector)
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+	if el == nil {
+		return mcp.NewToolResultError(
+			fmt.Sprintf("element %q not found", selector),
+		), nil
+	}
+
+	checked, err := el.IsChecked()
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+
+	return mcp.NewToolResultText(
+		fmt.Sprintf("%t", checked),
+	), nil
+}
+
+func (s *Session) handleIsDisabled(
+	_ context.Context,
+	req mcp.CallToolRequest,
+) (*mcp.CallToolResult, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	selector, err := req.RequireString("selector")
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+
+	page, _, err := s.pageFromRequest(req)
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+
+	el, err := page.Query(selector)
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+	if el == nil {
+		return mcp.NewToolResultError(
+			fmt.Sprintf("element %q not found", selector),
+		), nil
+	}
+
+	disabled, err := el.IsDisabled()
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+
+	return mcp.NewToolResultText(
+		fmt.Sprintf("%t", disabled),
+	), nil
+}
+
+func (s *Session) handleIsEditable(
+	_ context.Context,
+	req mcp.CallToolRequest,
+) (*mcp.CallToolResult, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	selector, err := req.RequireString("selector")
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+
+	page, _, err := s.pageFromRequest(req)
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+
+	el, err := page.Query(selector)
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+	if el == nil {
+		return mcp.NewToolResultError(
+			fmt.Sprintf("element %q not found", selector),
+		), nil
+	}
+
+	editable, err := el.IsEditable()
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+
+	return mcp.NewToolResultText(
+		fmt.Sprintf("%t", editable),
 	), nil
 }
 

--- a/tests/integration/element_test.go
+++ b/tests/integration/element_test.go
@@ -234,6 +234,144 @@ func TestPageScreenshot(t *testing.T) {
 	}
 }
 
+func TestElementIsChecked(t *testing.T) {
+	b := launchBrowser(t)
+	page := newPage(t, b)
+
+	page.SetContent(`<html><body>
+		<input id="on" type="checkbox" checked>
+		<input id="off" type="checkbox">
+	</body></html>`)
+
+	on, _ := page.Query("#on")
+	checked, err := on.IsChecked()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !checked {
+		t.Error("expected checked=true for #on")
+	}
+
+	off, _ := page.Query("#off")
+	checked, err = off.IsChecked()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if checked {
+		t.Error("expected checked=false for #off")
+	}
+}
+
+func TestElementIsDisabled(t *testing.T) {
+	b := launchBrowser(t)
+	page := newPage(t, b)
+
+	page.SetContent(`<html><body>
+		<input id="dis" type="text" disabled>
+		<input id="en" type="text">
+	</body></html>`)
+
+	dis, _ := page.Query("#dis")
+	disabled, err := dis.IsDisabled()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !disabled {
+		t.Error("expected disabled=true for #dis")
+	}
+
+	en, _ := page.Query("#en")
+	disabled, err = en.IsDisabled()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if disabled {
+		t.Error("expected disabled=false for #en")
+	}
+}
+
+func TestElementIsEditable(t *testing.T) {
+	b := launchBrowser(t)
+	page := newPage(t, b)
+
+	page.SetContent(`<html><body>
+		<input id="editable" type="text">
+		<input id="disabled-input" type="text" disabled>
+		<input id="readonly-input" type="text" readonly>
+		<div id="plain">text</div>
+		<div id="ce" contenteditable="true">edit me</div>
+	</body></html>`)
+
+	cases := []struct {
+		sel  string
+		want bool
+	}{
+		{"#editable", true},
+		{"#disabled-input", false},
+		{"#readonly-input", false},
+		{"#plain", false},
+		{"#ce", true},
+	}
+	for _, tc := range cases {
+		el, _ := page.Query(tc.sel)
+		got, err := el.IsEditable()
+		if err != nil {
+			t.Fatalf("%s: %v", tc.sel, err)
+		}
+		if got != tc.want {
+			t.Errorf("%s: editable=%t, want %t", tc.sel, got, tc.want)
+		}
+	}
+}
+
+func TestElementBlur(t *testing.T) {
+	b := launchBrowser(t)
+	page := newPage(t, b)
+
+	page.SetContent(`<html><body><input id="input" type="text"></body></html>`)
+
+	el, _ := page.Query("#input")
+	el.Focus()
+
+	tag, _ := page.Evaluate("document.activeElement.tagName")
+	if tag != "INPUT" {
+		t.Fatalf("activeElement = %v, want INPUT", tag)
+	}
+
+	if err := el.Blur(); err != nil {
+		t.Fatal(err)
+	}
+
+	tag, _ = page.Evaluate("document.activeElement.tagName")
+	if tag != "BODY" {
+		t.Errorf("after blur activeElement = %v, want BODY", tag)
+	}
+}
+
+func TestElementClear(t *testing.T) {
+	b := launchBrowser(t)
+	page := newPage(t, b)
+
+	page.SetContent(`<html><body><input id="input" type="text"></body></html>`)
+
+	el, _ := page.Query("#input")
+	el.Fill("hello world")
+
+	val, _ := page.Evaluate(`document.querySelector("#input").value`)
+	if val != "hello world" {
+		t.Fatalf("value = %v, want 'hello world'", val)
+	}
+
+	if err := el.Clear(); err != nil {
+		t.Fatal(err)
+	}
+
+	val, _ = page.Evaluate(`document.querySelector("#input").value`)
+	if val != "" {
+		t.Errorf("after clear value = %v, want empty", val)
+	}
+}
+
 func isTimeoutError(err error, target **bonk.TimeoutError) bool {
 	te, ok := err.(*bonk.TimeoutError)
 	if ok {

--- a/tests/integration/locator_test.go
+++ b/tests/integration/locator_test.go
@@ -76,6 +76,201 @@ func TestLocatorNeverStale(t *testing.T) {
 	}
 }
 
+func TestLocatorIsChecked(t *testing.T) {
+	b := launchBrowser(t)
+	page := newPage(t, b)
+
+	page.SetContent(`<html><body>
+		<input id="on" type="checkbox" checked>
+		<input id="off" type="checkbox">
+	</body></html>`)
+
+	checked, err := page.Locator("#on").IsChecked()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !checked {
+		t.Error("expected checked=true for #on")
+	}
+
+	checked, err = page.Locator("#off").IsChecked()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if checked {
+		t.Error("expected checked=false for #off")
+	}
+}
+
+func TestLocatorIsDisabled(t *testing.T) {
+	b := launchBrowser(t)
+	page := newPage(t, b)
+
+	page.SetContent(`<html><body>
+		<input id="dis" type="text" disabled>
+		<input id="en" type="text">
+	</body></html>`)
+
+	disabled, err := page.Locator("#dis").IsDisabled()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !disabled {
+		t.Error("expected disabled=true")
+	}
+
+	disabled, err = page.Locator("#en").IsDisabled()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if disabled {
+		t.Error("expected disabled=false")
+	}
+}
+
+func TestLocatorIsEditable(t *testing.T) {
+	b := launchBrowser(t)
+	page := newPage(t, b)
+
+	page.SetContent(`<html><body>
+		<input id="editable" type="text">
+		<input id="disabled-input" type="text" disabled>
+		<div id="plain">text</div>
+	</body></html>`)
+
+	editable, err := page.Locator("#editable").IsEditable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !editable {
+		t.Error("expected editable=true for #editable")
+	}
+
+	editable, err = page.Locator("#disabled-input").IsEditable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if editable {
+		t.Error("expected editable=false for #disabled-input")
+	}
+
+	editable, err = page.Locator("#plain").IsEditable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if editable {
+		t.Error("expected editable=false for #plain")
+	}
+}
+
+func TestLocatorFocus(t *testing.T) {
+	b := launchBrowser(t)
+	page := newPage(t, b)
+
+	page.SetContent(`<html><body><input id="input" type="text"></body></html>`)
+
+	if err := page.Locator("#input").Focus(); err != nil {
+		t.Fatal(err)
+	}
+
+	tag, _ := page.Evaluate("document.activeElement.tagName")
+	if tag != "INPUT" {
+		t.Errorf("activeElement = %v, want INPUT", tag)
+	}
+}
+
+func TestLocatorBlur(t *testing.T) {
+	b := launchBrowser(t)
+	page := newPage(t, b)
+
+	page.SetContent(`<html><body><input id="input" type="text"></body></html>`)
+
+	loc := page.Locator("#input")
+	loc.Focus()
+
+	if err := loc.Blur(); err != nil {
+		t.Fatal(err)
+	}
+
+	tag, _ := page.Evaluate("document.activeElement.tagName")
+	if tag != "BODY" {
+		t.Errorf("after blur activeElement = %v, want BODY", tag)
+	}
+}
+
+func TestLocatorClear(t *testing.T) {
+	b := launchBrowser(t)
+	page := newPage(t, b)
+
+	page.SetContent(`<html><body><input id="input" type="text"></body></html>`)
+
+	loc := page.Locator("#input")
+	loc.Fill("hello world")
+
+	if err := loc.Clear(); err != nil {
+		t.Fatal(err)
+	}
+
+	val, _ := page.Evaluate(`document.querySelector("#input").value`)
+	if val != "" {
+		t.Errorf("after clear value = %v, want empty", val)
+	}
+}
+
+func TestLocatorAllInnerTexts(t *testing.T) {
+	b := launchBrowser(t)
+	page := newPage(t, b)
+
+	page.SetContent(`<html><body>
+		<ul>
+			<li>Alpha</li>
+			<li>Bravo</li>
+			<li>Charlie</li>
+		</ul>
+	</body></html>`)
+
+	texts, err := page.Locator("li").AllInnerTexts()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(texts) != 3 {
+		t.Fatalf("got %d texts, want 3", len(texts))
+	}
+	want := []string{"Alpha", "Bravo", "Charlie"}
+	for i, w := range want {
+		if texts[i] != w {
+			t.Errorf("texts[%d] = %q, want %q", i, texts[i], w)
+		}
+	}
+}
+
+func TestLocatorAllTextContents(t *testing.T) {
+	b := launchBrowser(t)
+	page := newPage(t, b)
+
+	page.SetContent(`<html><body>
+		<ul>
+			<li>Alpha</li>
+			<li>Bravo</li>
+			<li>Charlie</li>
+		</ul>
+	</body></html>`)
+
+	texts, err := page.Locator("li").AllTextContents()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(texts) != 3 {
+		t.Fatalf("got %d texts, want 3", len(texts))
+	}
+	want := []string{"Alpha", "Bravo", "Charlie"}
+	for i, w := range want {
+		if texts[i] != w {
+			t.Errorf("texts[%d] = %q, want %q", i, texts[i], w)
+		}
+	}
+}
+
 func TestLocatorWaitFor(t *testing.T) {
 	b := launchBrowser(t)
 	page := newPage(t, b)

--- a/www/docs/automation/locators.md
+++ b/www/docs/automation/locators.md
@@ -28,6 +28,9 @@ loc.Click()
 loc.Fill("hello@example.com")
 loc.Type("query", bonk.WithDelay(50*time.Millisecond))
 loc.Press("Enter")
+loc.Focus()
+loc.Blur()
+loc.Clear()
 ```
 
 ## Read Properties
@@ -38,7 +41,19 @@ inner, err := loc.InnerText()
 html, err := loc.HTML()
 val, err := loc.Attribute("href")
 visible, err := loc.IsVisible()
+checked, err := loc.IsChecked()
+disabled, err := loc.IsDisabled()
+editable, err := loc.IsEditable()
 box, err := loc.BoundingBox()
+```
+
+## Bulk Text
+
+Retrieve text from all matching elements at once:
+
+```go
+texts, err := loc.AllInnerTexts()      // rendered innerText of each match
+contents, err := loc.AllTextContents()  // textContent of each match
 ```
 
 ## Screenshot

--- a/www/docs/core/element.md
+++ b/www/docs/core/element.md
@@ -35,6 +35,8 @@ err = el.Check()
 err = el.Uncheck()
 err = el.Upload("./file.pdf")
 err = el.Focus()
+err = el.Blur()
+err = el.Clear()
 err = el.ScrollIntoView()
 ```
 
@@ -46,6 +48,9 @@ inner, err := el.InnerText()     // innerText (rendered text)
 html, err := el.HTML()           // outerHTML
 val, err := el.Attribute("href")
 visible, err := el.IsVisible()
+checked, err := el.IsChecked()
+disabled, err := el.IsDisabled()
+editable, err := el.IsEditable()
 box, err := el.BoundingBox()     // *Box{X, Y, Width, Height}
 ```
 

--- a/www/docs/mcp/tools-reference.md
+++ b/www/docs/mcp/tools-reference.md
@@ -337,6 +337,39 @@ Wait for an element to appear in the page.
 | `timeout_ms` | number | no | Timeout in milliseconds (default 30000) |
 | `page_id` | string | no | Target page |
 
+### is_checked
+
+Check if a checkbox or radio button is checked.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `selector` | string | yes | CSS selector of the element |
+| `page_id` | string | no | Target page |
+
+Returns `"true"` or `"false"`.
+
+### is_disabled
+
+Check if an element is disabled.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `selector` | string | yes | CSS selector of the element |
+| `page_id` | string | no | Target page |
+
+Returns `"true"` or `"false"`.
+
+### is_editable
+
+Check if an element is editable (input, textarea, select, or contenteditable that is not disabled or readonly).
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `selector` | string | yes | CSS selector of the element |
+| `page_id` | string | no | Target page |
+
+Returns `"true"` or `"false"`.
+
 ## Cookies & State
 
 ### get_cookies


### PR DESCRIPTION
This pull request adds several new element and locator query and action methods, expands the automation API and MCP tools, and updates documentation and tests to cover these new capabilities. The main focus is to provide richer introspection and manipulation of web elements, such as checking if an element is checked, disabled, or editable, and supporting actions like blur and clear. These enhancements are exposed both in the core API and in the MCP tools interface.

closes #19 