### PR TITLE
feat: add accessibility snapshot handling and click reference tool

### DIFF
--- a/mcp/session.go
+++ b/mcp/session.go
@@ -52,6 +52,7 @@ type Session struct {
 	cfg       sessionConfig
 	routes    map[string]func()
 	overlays  map[string]*bonk.Locator
+	snapshots map[string][]*bonk.AXNode
 }
 
 // NewSession creates a new session with the given options.
@@ -61,10 +62,11 @@ func NewSession(opts ...SessionOption) *Session {
 		o(&cfg)
 	}
 	return &Session{
-		pages:    make(map[string]*bonk.Page),
-		routes:   make(map[string]func()),
-		overlays: make(map[string]*bonk.Locator),
-		cfg:      cfg,
+		pages:     make(map[string]*bonk.Page),
+		routes:    make(map[string]func()),
+		overlays:  make(map[string]*bonk.Locator),
+		snapshots: make(map[string][]*bonk.AXNode),
+		cfg:       cfg,
 	}
 }
 

--- a/mcp/tools_page.go
+++ b/mcp/tools_page.go
@@ -112,7 +112,9 @@ func registerPageTools(s *server.MCPServer, sess *Session) {
 					"Returns an indexed, structured view of "+
 					"all elements. Interactive elements get "+
 					"numbered indices. Use this to understand "+
-					"page structure before clicking or filling.",
+					"page structure before clicking or filling. "+
+					"Click a numbered element directly with "+
+					"click_ref.",
 			),
 			mcp.WithString("page_id",
 				mcp.Description(
@@ -122,6 +124,32 @@ func registerPageTools(s *server.MCPServer, sess *Session) {
 			),
 		),
 		sess.handleSnapshot,
+	)
+
+	s.AddTool(
+		mcp.NewTool("click_ref",
+			mcp.WithDescription(
+				"Click the interactive element at the given "+
+					"index from the most recent snapshot of "+
+					"the page (the number shown as [N]). More "+
+					"reliable than a selector for elements read "+
+					"from the snapshot.",
+			),
+			mcp.WithNumber("ref",
+				mcp.Required(),
+				mcp.Description(
+					"The [N] index of the element from the "+
+						"latest snapshot.",
+				),
+			),
+			mcp.WithString("page_id",
+				mcp.Description(
+					"ID of the page. "+
+						"Omit to use the default page.",
+				),
+			),
+		),
+		sess.handleClickRef,
 	)
 
 	s.AddTool(
@@ -358,7 +386,7 @@ func (s *Session) handleSnapshot(
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	page, _, err := s.pageFromRequest(req)
+	page, id, err := s.pageFromRequest(req)
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
 	}
@@ -368,11 +396,46 @@ func (s *Session) handleSnapshot(
 		return mcp.NewToolResultError(err.Error()), nil
 	}
 
-	text := bonk.FormatAccessibilityTree(nodes)
+	text, refs := bonk.FormatAccessibilityTreeIndexed(nodes)
+	s.snapshots[id] = refs
 	if text == "" {
 		text = "(empty accessibility tree)"
 	}
 	return mcp.NewToolResultText(text), nil
+}
+
+func (s *Session) handleClickRef(
+	_ context.Context,
+	req mcp.CallToolRequest,
+) (*mcp.CallToolResult, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	ref := int(req.GetFloat("ref", 0))
+
+	page, id, err := s.pageFromRequest(req)
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+
+	refs := s.snapshots[id]
+	if len(refs) == 0 {
+		return mcp.NewToolResultError(
+			"no snapshot for this page; call snapshot first",
+		), nil
+	}
+	if ref < 1 || ref > len(refs) {
+		return mcp.NewToolResultError(
+			fmt.Sprintf("ref %d out of range 1..%d", ref, len(refs)),
+		), nil
+	}
+
+	if err := page.ClickNode(refs[ref-1]); err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+	return mcp.NewToolResultText(
+		fmt.Sprintf("Clicked [%d]", ref),
+	), nil
 }
 
 func (s *Session) handlePause(

--- a/page_accessibility.go
+++ b/page_accessibility.go
@@ -10,16 +10,17 @@ import (
 
 // AXNode represents a node in the accessibility tree.
 type AXNode struct {
-	Role     string
-	Name     string
-	Value    string
-	Disabled bool
-	Focused  bool
-	Checked  string
-	Selected bool
-	Expanded string
-	Level    int
-	Children []*AXNode
+	Role          string
+	Name          string
+	Value         string
+	Disabled      bool
+	Focused       bool
+	Checked       string
+	Selected      bool
+	Expanded      string
+	Level         int
+	BackendNodeID proto.BackendNodeID
+	Children      []*AXNode
 }
 
 var interactiveRoles = map[string]bool{
@@ -84,6 +85,38 @@ func (p *Page) AccessibilityTree() ([]*AXNode, error) {
 	return result, nil
 }
 
+// ElementForNode resolves an accessibility node to a live Element via its
+// backend DOM node id, so a node read from AccessibilityTree can be acted on
+// directly without re-locating it by accessible name.
+func (p *Page) ElementForNode(n *AXNode) (*Element, error) {
+	if n == nil || n.BackendNodeID == 0 {
+		return nil, fmt.Errorf("bonk: accessibility node has no backend node id")
+	}
+	res, err := proto.DOMResolveNode().
+		WithBackendNodeID(n.BackendNodeID).
+		Do(p.execCtx)
+	if err != nil {
+		return nil, fmt.Errorf("bonk: resolve accessibility node: %w", err)
+	}
+	if res.Object.ObjectID == "" {
+		return nil, fmt.Errorf("bonk: accessibility node did not resolve to an element")
+	}
+	return &Element{page: p, objectID: res.Object.ObjectID}, nil
+}
+
+// ClickNode resolves an accessibility node and clicks it by dispatching a native
+// DOM click on the element. Unlike a coordinate-based click, this reliably
+// triggers links and buttons even when an overlay covers the element's centre or
+// hit-testing would otherwise send the click elsewhere.
+func (p *Page) ClickNode(n *AXNode) error {
+	el, err := p.ElementForNode(n)
+	if err != nil {
+		return err
+	}
+	_, err = p.EvaluateOn(el, "function(){ this.click() }")
+	return err
+}
+
 func buildAXNode(
 	lookup map[proto.AccessibilityAXNodeID]*proto.AccessibilityAXNode,
 	id proto.AccessibilityAXNodeID,
@@ -130,9 +163,10 @@ func buildAXNode(
 	}
 
 	node := &AXNode{
-		Role:  role,
-		Name:  axValueString(raw.Name),
-		Value: axValueString(raw.Value),
+		Role:          role,
+		Name:          axValueString(raw.Name),
+		Value:         axValueString(raw.Value),
+		BackendNodeID: raw.BackendDOMNodeID,
 	}
 
 	for _, prop := range raw.Properties {
@@ -165,12 +199,23 @@ func buildAXNode(
 // for LLM consumption. Interactive elements get numbered
 // indices; non-interactive elements are shown without indices.
 func FormatAccessibilityTree(nodes []*AXNode) string {
+	text, _ := FormatAccessibilityTreeIndexed(nodes)
+	return text
+}
+
+// FormatAccessibilityTreeIndexed formats the tree like FormatAccessibilityTree
+// and also returns the interactive nodes in index order: the element shown as
+// [i] in the text is refs[i-1]. Pass a ref to Page.ClickNode or
+// Page.ElementForNode to act on exactly the element that was shown, instead of
+// re-locating it by accessible name.
+func FormatAccessibilityTreeIndexed(nodes []*AXNode) (string, []*AXNode) {
 	var b strings.Builder
+	var refs []*AXNode
 	idx := 1
 	for _, n := range nodes {
-		formatNode(&b, n, 0, &idx)
+		formatNode(&b, n, 0, &idx, &refs)
 	}
-	return b.String()
+	return b.String(), refs
 }
 
 func formatNode(
@@ -178,10 +223,11 @@ func formatNode(
 	n *AXNode,
 	depth int,
 	idx *int,
+	refs *[]*AXNode,
 ) {
 	if n.Role == "" && len(n.Children) > 0 {
 		for _, c := range n.Children {
-			formatNode(b, c, depth, idx)
+			formatNode(b, c, depth, idx, refs)
 		}
 		return
 	}
@@ -195,6 +241,7 @@ func formatNode(
 	if interactiveRoles[n.Role] {
 		fmt.Fprintf(b, "%s[%d] %s", indent, *idx, n.Role)
 		*idx++
+		*refs = append(*refs, n)
 	} else {
 		fmt.Fprintf(b, "%s%s", indent, n.Role)
 	}
@@ -232,7 +279,7 @@ func formatNode(
 	b.WriteByte('\n')
 
 	for _, c := range n.Children {
-		formatNode(b, c, depth+1, idx)
+		formatNode(b, c, depth+1, idx, refs)
 	}
 }
 

--- a/tests/integration/accessibility_test.go
+++ b/tests/integration/accessibility_test.go
@@ -1,0 +1,51 @@
+package integration
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/joakimcarlsson/bonk"
+)
+
+func TestAccessibilitySnapshotClickByNode(t *testing.T) {
+	b := launchBrowser(t)
+	page := newPage(t, b)
+
+	page.Navigate("about:blank")
+	page.SetContent(`<html><body>
+		<button onclick="location.hash='b1'">Go</button>
+		<button onclick="location.hash='b2'">Go</button>
+		<button onclick="location.hash='b3'">Go</button>
+	</body></html>`)
+
+	nodes, err := page.AccessibilityTree()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, refs := bonk.FormatAccessibilityTreeIndexed(nodes)
+	var buttons []*bonk.AXNode
+	for _, n := range refs {
+		if n.Role == "button" {
+			buttons = append(buttons, n)
+		}
+	}
+	if len(buttons) != 3 {
+		t.Fatalf("button nodes = %d, want 3", len(buttons))
+	}
+	if buttons[1].BackendNodeID == 0 {
+		t.Fatal("node has no backend node id")
+	}
+
+	if err := page.ClickNode(buttons[1]); err != nil {
+		t.Fatal(err)
+	}
+
+	hash, err := page.Evaluate("location.hash")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := fmt.Sprint(hash); got != "#b2" {
+		t.Errorf("hash = %q, want %q (clicked the wrong same-named button)", got, "#b2")
+	}
+}

--- a/tests/mcp/clickref_test.go
+++ b/tests/mcp/clickref_test.go
@@ -1,0 +1,43 @@
+package mcp_test
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestClickRef(t *testing.T) {
+	c, _ := setupServer(t)
+
+	callTool(t, c, "navigate", map[string]any{"url": "about:blank"})
+	callTool(t, c, "evaluate", map[string]any{
+		"expression": `document.body.innerHTML = '<button onclick="window.clicked=1">Go</button><button onclick="window.clicked=2">Go</button>'`,
+	})
+
+	snap := resultText(t, callTool(t, c, "snapshot", nil))
+	if !strings.Contains(snap, "[1]") || !strings.Contains(snap, "[2]") {
+		t.Fatalf("snapshot missing indexed buttons:\n%s", snap)
+	}
+
+	res := callTool(t, c, "click_ref", map[string]any{"ref": 2})
+	if res.IsError {
+		t.Fatalf("click_ref failed: %s", resultText(t, res))
+	}
+
+	got := resultText(t, callTool(t, c, "evaluate", map[string]any{
+		"expression": "window.clicked",
+	}))
+	if !strings.Contains(got, "2") {
+		t.Errorf("window.clicked = %q, want 2 (clicked the wrong button)", got)
+	}
+}
+
+func TestClickRefWithoutSnapshot(t *testing.T) {
+	c, _ := setupServer(t)
+
+	callTool(t, c, "navigate", map[string]any{"url": "about:blank"})
+
+	res := callTool(t, c, "click_ref", map[string]any{"ref": 1})
+	if !res.IsError {
+		t.Fatal("click_ref without a prior snapshot should error")
+	}
+}

--- a/www/docs/mcp/tools-reference.md
+++ b/www/docs/mcp/tools-reference.md
@@ -152,6 +152,14 @@ Get the full HTML content of the page.
 |-----------|------|----------|-------------|
 | `page_id` | string | no | Target page |
 
+### snapshot
+
+Get the accessibility tree of the page as indexed, structured text. Interactive elements get numbered indices (`[N]`). Use it to understand page structure before acting; the numbered elements can be clicked directly with `click_ref`.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `page_id` | string | no | Target page |
+
 ### evaluate
 
 Execute JavaScript in the page.
@@ -213,6 +221,15 @@ Click an element.
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `selector` | string | yes | CSS selector of the element |
+| `page_id` | string | no | Target page |
+
+### click_ref
+
+Click the interactive element at the given index from the page's most recent `snapshot` (the number shown as `[N]`). More reliable than a selector for elements read from the snapshot, since it acts on that exact node. Call `snapshot` first.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `ref` | number | yes | The `[N]` index of the element from the latest snapshot |
 | `page_id` | string | no | Target page |
 
 ### fill


### PR DESCRIPTION
This pull request introduces a new way to interact with web pages using accessibility snapshots, allowing elements to be reliably clicked by their indexed reference rather than by selector. The main feature is the addition of the `click_ref` tool, which lets users trigger clicks on elements as they appear in the most recent accessibility snapshot, ensuring the correct element is targeted even when there are duplicates or overlays. Several supporting changes were made to enable this, including enhancements to the accessibility tree, new methods for resolving and clicking nodes, and updates to documentation and tests.